### PR TITLE
Replace some get_action().add_action calls

### DIFF
--- a/Javatar.py
+++ b/Javatar.py
@@ -6,12 +6,12 @@ def startup():
     EventHandler.register_handler(on_change, EventHandler.ON_NEW | EventHandler.ON_ACTIVATED | EventHandler.ON_LOAD | EventHandler.ON_POST_SAVE | EventHandler.ON_CLONE)
     EventHandler.register_handler(on_project_stable, EventHandler.ON_CLOSE | EventHandler.ON_NEW | EventHandler.ON_POST_WINDOW_COMMAND)
     start_clock()
-    get_action().add_action("javatar", "Startup")
+    add_action("javatar", "Startup")
     reset()  # clear data when restart
     read_settings("Javatar.sublime-settings")
     check_news()
     hide_status()
-    get_action().add_action("javatar", "Ready")
+    add_action("javatar", "Ready")
 
 
 def plugin_loaded():

--- a/commands/javatar_build.py
+++ b/commands/javatar_build.py
@@ -98,7 +98,9 @@ class JavatarBuildCommand(sublime_plugin.WindowCommand):
         if self.build_size < 0:
             show_notification("Building Cancelled")
             sublime.status_message("Building Cancelled")
-            get_action().add_action("javatar.command.build.complete", "Building Cancelled")
+            add_action(
+                "javatar.command.build.complete", "Building Cancelled"
+            )
             return
 
         message = "Building Finished [{0:.2f}s]"
@@ -110,7 +112,10 @@ class JavatarBuildCommand(sublime_plugin.WindowCommand):
         if self.view is not None:
             self.view.set_name(message.format(clock()-self.start_time))
         sublime.status_message(message.format(clock()-self.start_time))
-        get_action().add_action("javatar.command.build.complete", message.format(clock()-self.start_time))
+        add_action(
+            "javatar.command.build.complete",
+            message.format(clock()-self.start_time)
+        )
 
     def get_java_files(self, dir_path):
         for name in os.listdir(dir_path):
@@ -123,7 +128,9 @@ class JavatarBuildCommand(sublime_plugin.WindowCommand):
     def build_all(self, dir_path):
         self.get_java_files(dir_path)
         if len(self.build_list) > 0:
-            get_action().add_action("javatar.command.build.build_all", "Build all")
+            add_action(
+                "javatar.command.build.build_all", "Build all"
+            )
             self.build()
             return True
         else:
@@ -132,7 +139,10 @@ class JavatarBuildCommand(sublime_plugin.WindowCommand):
     def run(self, build_type=""):
         self.macro_data = get_macro_data()
         self.build_list = []
-        get_action().add_action("javatar.command.build.run", "Build [build_type=" + build_type + "]")
+        add_action(
+            "javatar.command.build.run",
+            "Build [build_type=" + build_type + "]"
+        )
         view = sublime.active_window().active_view()
         if build_type == "project":
             if is_project():
@@ -174,7 +184,10 @@ class JavatarBuildCommand(sublime_plugin.WindowCommand):
                                 sublime.error_message("Some Java files are not saved")
                                 return
                 if len(self.build_list) > 0:
-                    get_action().add_action("javatar.command.build.build_working", "Build working files")
+                    add_action(
+                        "javatar.command.build.build_working",
+                        "Build working files"
+                    )
                     self.build()
                 else:
                     sublime.error_message("No class to build")
@@ -189,7 +202,9 @@ class JavatarBuildCommand(sublime_plugin.WindowCommand):
                         else:
                             sublime.error_message("Current file is not saved")
                             return
-                    get_action().add_action("javatar.command.build.build_file", "Build file")
+                    add_action(
+                        "javatar.command.build.build_file", "Build file"
+                    )
                     self.build_list.append(view.file_name())
                     self.build()
                 else:

--- a/commands/javatar_call.py
+++ b/commands/javatar_call.py
@@ -4,7 +4,10 @@ from ..utils import *
 
 class JavatarCallCommand(sublime_plugin.TextCommand):
     def run(self, edit, call_type=""):
-        get_action().add_action("javatar.command.call.run", "Call [call_type=" + call_type + "]")
+        add_action(
+            "javatar.command.call.run",
+            "Call [call_type=" + call_type + "]"
+        )
         if not is_java():
             sublime.error_message("Current file is not Java")
             return

--- a/commands/javatar_install.py
+++ b/commands/javatar_install.py
@@ -11,7 +11,13 @@ class JavatarInstallCommand(sublime_plugin.WindowCommand):
 
     def run(self, installtype=None, name=None, filename=None, url=None, checksum=None):
         if installtype is not None:
-            get_action().add_action("javatar.command.install.run", "Install Package [type="+installtype+", name="+name+"]")
+            add_action(
+                "javatar.command.install.run",
+                "Install Package [type={}, name={}]".format(
+                    installtype,
+                    name
+                )
+            )
             self.pname = name
             if installtype == "remote_package":
                 self.action = "install"

--- a/commands/javatar_menu.py
+++ b/commands/javatar_menu.py
@@ -335,6 +335,17 @@ class JavatarCommand(sublime_plugin.WindowCommand):
 
     def select(self, info):
         if info["index"] < 0:
-            get_action().add_action("javatar.command.menu.select", "Exit menu [from_sublime="+str(info["from_sublime"])+"]")
+            add_action(
+                "javatar.command.menu.select",
+                "Exit menu [from_sublime={}]".format(
+                    info["from_sublime"]
+                )
+            )
         else:
-            get_action().add_action("javatar.command.menu.select", "Select item " + str(info["items"][info["index"]]) + " [from_sublime="+str(info["from_sublime"])+"]")
+            add_action(
+                "javatar.command.menu.select",
+                "Select item {} [from_sublime={}]".format(
+                    info["items"][info["index"]],
+                    info["from_sublime"]
+                )
+            )

--- a/commands/javatar_operation.py
+++ b/commands/javatar_operation.py
@@ -18,7 +18,9 @@ class JavatarTestOperationCommand(sublime_plugin.WindowCommand):
 
 class JavatarCorrectClassCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        get_action().add_action("javatar.command.operation.correct_class.run", "Correct class")
+        add_action(
+            "javatar.command.operation.correct_class.run", "Correct class"
+        )
         if is_file() and is_java():
             packageName = get_current_package()
             packageRegions = self.view.find_by_selector(get_settings("package_name_selector"))
@@ -145,8 +147,11 @@ class JavatarOrganizeImportsCommand(sublime_plugin.TextCommand):
                 self.index = 0
                 self.run(edit, 3)
         elif step == 2:
-            #select classes callback
-            get_action().add_action("javatar.command.operation.organize_imports.step2", "Organize Imports [step=2] Select classes callback")
+            # select classes callback
+            add_action(
+                "javatar.command.operation.organize_imports.step2",
+                "Organize Imports [step=2] Select classes callback"
+            )
             if isinstance(self.selectedPackage, int):
                 if self.needImportTypes[self.index] not in self.postAskTypes:
                     self.postAskTypes.append(self.needImportTypes[self.index])
@@ -165,8 +170,11 @@ class JavatarOrganizeImportsCommand(sublime_plugin.TextCommand):
             else:
                 self.run(edit, 1)
         elif step == 3:
-            #add default imports
-            get_action().add_action("javatar.command.operation.organize_imports.step3", "Organize Imports [step=3] Add default imports")
+            # add default imports
+            add_action(
+                "javatar.command.operation.organize_imports.step3",
+                "Organize Imports [step=3] Add default imports"
+            )
             for packageImport in get_packages():
                 importOnce = False
                 if "packages" in packageImport:
@@ -189,16 +197,22 @@ class JavatarOrganizeImportsCommand(sublime_plugin.TextCommand):
                             self.alwaysImportedPackages.append(packageName)
             self.run(edit, 4)
         elif step == 4:
-            #ask package
-            get_action().add_action("javatar.command.operation.organize_imports.step4", "Organize Imports [step=4] Ask package")
+            # ask package
+            add_action(
+                "javatar.command.operation.organize_imports.step4",
+                "Organize Imports [step=4] Ask package"
+            )
             self.askTypes += self.postAskTypes
             if len(self.askTypes) > 0 and self.index < len(self.askTypes):
                 self.askPackage(-1, self.askTypes[self.index])
             else:
                 self.run(edit, 6)
         elif step == 5:
-            #ask package callback
-            get_action().add_action("javatar.command.operation.organize_imports.step5", "Organize Imports [step=5] Ask package callback")
+            # ask package callback
+            add_action(
+                "javatar.command.operation.organize_imports.step5",
+                "Organize Imports [step=5] Ask package callback"
+            )
             if self.selectedPackage is not None:
                 self.importedPackages.append(self.selectedPackage)
                 if get_package_path(self.selectedPackage) in self.importedPackagesStat:
@@ -212,8 +226,11 @@ class JavatarOrganizeImportsCommand(sublime_plugin.TextCommand):
             else:
                 self.run(edit, 4)
         elif step == 6:
-            #import
-            get_action().add_action("javatar.command.operation.organize_imports.step6", "Organize Imports [step=6] Import")
+            # import
+            add_action(
+                "javatar.command.operation.organize_imports.step6",
+                "Organize Imports [step=6] Import"
+            )
             importCode = ""
 
             #clear old imports
@@ -282,7 +299,10 @@ class JavatarOrganizeImportsCommand(sublime_plugin.TextCommand):
                 self.selectedPackage = None
             else:
                 if self.classes[index] == "Enter Package Manually":
-                    get_action().add_action("javatar.command.operation.organize_imports.step2", "Organize Imports - Enter Package Manually")
+                    add_action(
+                        "javatar.command.operation.organize_imports.step2",
+                        "Organize Imports - Enter Package Manually"
+                    )
                     self.selectedPackage = -1
                 else:
                     self.selectedPackage = self.classes[index]
@@ -312,7 +332,11 @@ class JavatarOrganizeImportsCommand(sublime_plugin.TextCommand):
 
 class JavatarRenameOperationCommand(sublime_plugin.WindowCommand):
     def run(self, text="", rename_type=""):
-        get_action().add_action("javatar.command.operation.rename.run", "Rename [rename_type="+rename_type+"]")
+        add_action(
+            "javatar.command.operation.rename.run",
+            "Rename [rename_type={}]"
+            .format(rename_type)
+        )
         if rename_type == "class":
             if is_file() and is_java():
                 classRegion = sublime.active_window().active_view().find(get_settings("class_name_prefix")+get_settings("class_name_scope")+get_settings("class_name_suffix"), 0)

--- a/commands/javatar_package.py
+++ b/commands/javatar_package.py
@@ -164,7 +164,10 @@ class JavatarCreateJavatarPackageCommand(sublime_plugin.WindowCommand):
     def run(self, first=True, again=False):
         if first:
             self.package_info = []
-            get_action().add_action("javatar.command.package.create_javatar_package.run", "Create Javatar Package")
+            add_action(
+                "javatar.command.package.create_javatar_package.run",
+                "Create Javatar Package"
+            )
         if self.package_step is None:
             self.package_step = [
                 {"input": "Package Name", "flags": "not empty", "message": "Welcome to Javatar Packages wizard\n   This wizard will helps you through package creation and automated some tasks for you.\n   First, you must ensure that you already place \"JavatarDoclet\" in " + get_path("parent", get_package_root_dir()) + "\n\nWizard will ask you for the following infomations...\n - Package name: This will be your package name which appear on installation\n - Preferred file name: This will be your package file name that will be created and uploaded to packages channel\n - Conflicted packages: This informations help users install your package without conflicting another package\n - Source folder: You will be asked for source folder to generate a proper .javatar-packages file\n\nTo cancel, dismiss this dialog and press \"Escape\" key"},
@@ -221,7 +224,10 @@ class JavatarCreatePackageCommand(sublime_plugin.WindowCommand):
         hide_status(clear=True)
 
     def createPackage(self, text, on_change=False):
-        get_action().add_action("javatar.command.package.create_package", "Create package [package="+text+"]")
+        add_action(
+            "javatar.command.package.create_package",
+            Create package [package="+text
+        +"]")
         relative = True
         if text.startswith("~"):
             text = text[1:]

--- a/commands/javatar_run.py
+++ b/commands/javatar_run.py
@@ -31,7 +31,7 @@ class JavatarRunMainCommand(sublime_plugin.WindowCommand):
             sublime.error_message("Unknown package location")
 
     def on_run(self):
-        get_action().add_action("javatar.command.run.on_run", "Run main class")
+        add_action("javatar.command.run.on_run", "Run main class")
         view = sublime.active_window().active_view()
         file_path = view.file_name()
         self.class_name = get_main_class_name(file_path, view)

--- a/commands/javatar_settings.py
+++ b/commands/javatar_settings.py
@@ -63,7 +63,10 @@ class JavatarSettingsCommand(sublime_plugin.WindowCommand):
         return dir_list
 
     def run(self, actiontype, arg1=None, arg2=None):
-        get_action().add_action("javatar.command.project.run", "Project Settings [type="+actiontype+"]")
+        add_action(
+            "javatar.command.project.run",
+            "Project Settings [type={}]".format(actiontype)
+        )
         self.actiontype = actiontype
         if actiontype == "set_source_folder":
             self.panel_list = self.get_folders()

--- a/commands/javatar_utils.py
+++ b/commands/javatar_utils.py
@@ -127,7 +127,9 @@ class JavatarUtilCommand(sublime_plugin.TextCommand):
 
 class JavatarReload_packagesCommand(sublime_plugin.WindowCommand):
     def run(self):
-        get_action().add_action("javatar.command.utils.reload_packages.run", "Reload Packages")
+        add_action(
+            "javatar.command.utils.reload_packages.run", "Reload Packages"
+        )
         reset_packages()
         load_packages()
 

--- a/utils/javatar_actions.py
+++ b/utils/javatar_actions.py
@@ -33,3 +33,7 @@ def get_action():
     if ACTION is None:
         ACTION = ActionList()
     return ACTION
+
+
+def add_action(name, action):
+    get_action().add_action(name, action)

--- a/utils/javatar_collections.py
+++ b/utils/javatar_collections.py
@@ -17,14 +17,18 @@ Allow a new javatar format for packaging a custom jar file (atleast easier for b
 
 
 def reset_snippets_and_packages():
-    get_action().add_action("javatar.util.collection.reset", "Reset all snippets")
+    add_action(
+        "javatar.util.collection.reset", "Reset all snippets"
+    )
     global SNIPPETS
     SNIPPETS = []
     reset_packages()
 
 
 def reset_packages():
-    get_action().add_action("javatar.util.collection.reset", "Reset all default packages")
+    add_action(
+        "javatar.util.collection.reset", "Reset all default packages"
+    )
     global INSTALLED_PACKAGES, DEFAULT_PACKAGES
     INSTALLED_PACKAGES = []
     DEFAULT_PACKAGES = []
@@ -42,7 +46,9 @@ def get_installed_package(name):
 
 
 def load_snippets_and_packages():
-    get_action().add_action("javatar.util.collection.get_snippet_files", "Load snippets")
+    add_action(
+        "javatar.util.collection.get_snippet_files", "Load snippets"
+    )
     thread = JavatarSnippetsLoaderThread(snippets_complete)
     thread.start()
     ThreadProgress(thread, "Loading Javatar snippets", "Javatar snippets has been loaded")
@@ -55,7 +61,10 @@ def snippets_complete(data):
 
 
 def load_packages(no_require=False):
-    get_action().add_action("javatar.util.collection.get_package_files", "Load Java default packages")
+    add_action(
+        "javatar.util.collection.get_package_files",
+        "Load Java default packages"
+    )
     thread = JavatarPackagesLoaderThread(packages_complete, no_require)
     thread.start()
     ThreadProgress(thread, "Loading Javatar packages", "Javatar packages has been loaded")
@@ -189,7 +198,10 @@ class JavatarSnippetsLoaderThread(threading.Thread):
         threading.Thread.__init__(self)
 
     def analyse_snippet(self, file):
-        get_action().add_action("javatar.util.collection.analyse_snippet", "Analyse snippet [file="+file+"]")
+        add_action(
+            "javatar.util.collection.analyse_snippet",
+            "Analyse snippet [file="+file+"]"
+        )
         data = sublime.load_resource(file)
         classScope = None
         classRe = re.search("%class:(.*)%(\\s*)", data, re.M)
@@ -218,7 +230,10 @@ class JavatarSnippetsLoaderThread(threading.Thread):
         from .javatar_utils import get_path
         for filepath in sublime.find_resources("*.javatar"):
             filename = get_path("name", filepath)
-            get_action().add_action("javatar.util.collection", "Javatar snippet " + filename + " loaded")
+            add_action(
+                "javatar.util.collection",
+                "Javatar snippet " + filename + " loaded"
+            )
             print("Javatar snippet " + filename + " loaded")
             snippets.append(self.analyse_snippet(filepath))
 
@@ -258,7 +273,10 @@ class JavatarPackagesLoaderThread(threading.Thread):
         return [packages, classes]
 
     def analyse_package(self, filepath):
-        get_action().add_action("javatar.util.collection.analyse_import", "Analyse package [file="+filepath+"]")
+        add_action(
+            "javatar.util.collection.analyse_import",
+            "Analyse package [file="+filepath+"]"
+        )
         try:
             from .javatar_utils import get_path
             imports = sublime.decode_value(sublime.load_resource(filepath))
@@ -280,7 +298,10 @@ class JavatarPackagesLoaderThread(threading.Thread):
         from .javatar_utils import get_path
         for filepath in sublime.find_resources("*.javatar-packages"):
             filename = get_path("name", filepath)
-            get_action().add_action("javatar.util.collection", "Javatar default package " + filename + " loaded")
+            add_action(
+                "javatar.util.collection",
+                "Javatar default package " + filename + " loaded"
+            )
             imports = self.analyse_package(filepath)
             if imports is not None:
                 default_packages.append(imports)

--- a/utils/javatar_news.py
+++ b/utils/javatar_news.py
@@ -33,17 +33,19 @@ def show_news(title, prefix=""):
 
 
 def check_news():
-    get_action().add_action("javatar.util.news", "Check news")
+    add_action("javatar.util.news", "Check news")
     from .javatar_utils import get_settings, set_settings, is_stable
     if get_settings("message_id") < NEWSID:
         if get_settings("message_id") != -1:
             stop_clock(notify=False)
             if is_stable() and (UPDATEFOR == "stable" or UPDATEFOR == "all"):
                 show_news("Javatar: Package has been updated!")
-                get_action().add_action("javatar.util.news", "Show stable news")
+                add_action(
+                    "javatar.util.news", "Show stable news"
+                )
             elif not is_stable() and (UPDATEFOR == "dev" or UPDATEFOR == "all"):
                 show_news("Javatar [Dev]: Package has been updated!")
-                get_action().add_action("javatar.util.news", "Show dev news")
+                add_action("javatar.util.news", "Show dev news")
             start_clock()
             send_usages(get_usage_data())
             set_settings("message_id", NEWSID)

--- a/utils/javatar_updater.py
+++ b/utils/javatar_updater.py
@@ -30,7 +30,7 @@ def send_package_action_complete(thread):
 
 
 def update_packages(no_require=False):
-    get_action().add_action("javatar.util.updater", "Check packages update")
+    add_action("javatar.util.updater", "Check packages update")
     thread = JavatarPackageUpdaterThread(update_complete)
     thread.no_require = no_require
     thread.start()
@@ -45,7 +45,10 @@ def update_complete(packageURL, require_package):
         package_conflict = require_package["conflict"]
     for conflict in package_conflict:
         if get_installed_package(conflict) is not None:
-            get_action().add_action("javatar.util.updater", "Conflict package was already installed")
+            add_action(
+                "javatar.util.updater",
+                "Conflict package was already installed"
+            )
             return
     get_action().add_action("javatar.util.updater", "Install default package")
     sublime.active_window().run_command("javatar_install", {"installtype": "remote_package", "name": require_package["name"], "filename": require_package["filename"], "url": packageURL, "checksum": require_package["hash"]})

--- a/utils/javatar_utils.py
+++ b/utils/javatar_utils.py
@@ -34,7 +34,7 @@ def stop_clock(add=True, notify=True):
 
 
 def reset():
-    get_action().add_action("javatar.util.util.reset", "Reset all settings")
+    add_action("javatar.util.util.reset", "Reset all settings")
     global SUBLIME_SETTINGS, SETTINGS, SETTINGSBASE
     SUBLIME_SETTINGS = None
     SETTINGS = None
@@ -72,7 +72,7 @@ def restore_project_state():
 
 
 def read_settings(config):
-    get_action().add_action("javatar.util.util.read_settings", "Read settings")
+    add_action("javatar.util.util.read_settings", "Read settings")
     global SUBLIME_SETTINGS, SETTINGS, SETTINGSBASE
     SETTINGSBASE = config
     SETTINGS = sublime.load_settings(config)


### PR DESCRIPTION
With this pattern used so often, it's best to use a shortcut.
In reality though, this functionality should really be replaced with a
logging framework, such as the inbuilt `logging` module. It is rather
extensible and could easily replace the existing action functionality.

I'll be submitting some more requests in the next couple of days :)
