### PR TITLE
Set Program Arguments Improvements

### DIFF
--- a/commands/javatar_settings.py
+++ b/commands/javatar_settings.py
@@ -130,7 +130,7 @@ class JavatarSettingsCommand(sublime_plugin.WindowCommand):
     def set_program_arguments(self, arg1=None, arg2=None):
         program_arguments = get_settings("program_arguments")
         panel = sublime.active_window().show_input_panel("Arguments to pass to main: ", program_arguments, self.on_input_done, None, self.on_input_cancel)
-        panel.sel().add(sublime.Region(0, panel.size()))
+        panel.sel().add(sublime.Region(0, panel.size())) # select the current value for fast editing
 
     def set_jdk(self, arg1=None, arg2=None):
         self.local = arg1


### PR DESCRIPTION
- \+ show current program args when setting them (easier to quickly modify current args or view the arguments set without the need to go in the config)
- \+ automatically select current program args text when initially changing it (so that clearing the prog args or completely changing them can be done without friction)
- \+ status message when cancelling the `Set Program Arguments` command (to indicate that the arguments remained the same)
- ! fix set_program_arguments that didn't get its arg1 and arg2 added as parameters on recent refactor
- \* refactor `javatar_settings` to avoid duplication of the `sublime timeout + show_status` sequence (see member function `show_delayed_status` in `javatar_settings`)
